### PR TITLE
Add radio button, checkbox sample examples

### DIFF
--- a/app/src/main/java/com/chch/mycompose/core/navigation/NavRoute.kt
+++ b/app/src/main/java/com/chch/mycompose/core/navigation/NavRoute.kt
@@ -14,6 +14,7 @@ import com.chch.mycompose.ui.screen.dialogs.DialogsPage
 import com.chch.mycompose.ui.screen.imageslider.ImageSliderScreen
 import com.chch.mycompose.ui.screen.numeric.NumericKeypadPage
 import com.chch.mycompose.ui.screen.pip.PIPScreen
+import com.chch.mycompose.ui.screen.selection.RadioCheckboxPage
 
 //Defined routes in Navigation using the NaviScreenRoute data class
 @SuppressLint("SupportAnnotationUsage")
@@ -82,6 +83,13 @@ fun getRoutes(): List<NavRoute> {
             deepLinkUri = null
         ) { _, nc ->
             ChecklistScreen(nc)
+        },
+        NavRoute(
+            route = "radioAndCheckbox",
+            titleRes = R.string.radio_and_checkbox,
+            deepLinkUri = null
+        ) { _, nc ->
+            RadioCheckboxPage(nc)
         }
 
     )

--- a/app/src/main/java/com/chch/mycompose/ui/component/BorderedSection.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/component/BorderedSection.kt
@@ -1,0 +1,49 @@
+package com.chch.mycompose.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BorderedSection(
+    modifier: Modifier = Modifier,
+    title: String,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        Modifier.padding(15.dp)
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .border(width = 2.dp, color = Color.Black, shape = RoundedCornerShape(10.dp))
+                .padding(16.dp)
+        ) {
+            content()
+        }
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(horizontal = 8.dp)
+                .align(Alignment.TopCenter)
+                .offset(y = (-8).dp)
+        )
+
+    }
+
+}

--- a/app/src/main/java/com/chch/mycompose/ui/component/CheckboxWithText.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/component/CheckboxWithText.kt
@@ -1,0 +1,33 @@
+package com.chch.mycompose.ui.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CheckboxWithText(
+    text: String,
+    checked: Boolean,
+    onChecked: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onChecked
+        )
+        Spacer(Modifier.width(5.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/java/com/chch/mycompose/ui/component/CheckboxWithText.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/component/CheckboxWithText.kt
@@ -1,5 +1,6 @@
 package com.chch.mycompose.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
@@ -18,6 +19,7 @@ fun CheckboxWithText(
     onChecked: (Boolean) -> Unit,
 ) {
     Row(
+        modifier = Modifier.clickable(onClick = { onChecked.invoke(!checked) }),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(

--- a/app/src/main/java/com/chch/mycompose/ui/component/RadioWithText.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/component/RadioWithText.kt
@@ -1,0 +1,31 @@
+package com.chch.mycompose.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RadioWithText(
+    modifier: Modifier = Modifier,
+    selected: Boolean,
+    text: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier.clickable(onClick = { onClick.invoke() })
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = null
+        )
+        Spacer(Modifier.width(5.dp))
+        Text(text = text, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/AgreementOption.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/AgreementOption.kt
@@ -1,0 +1,14 @@
+package com.chch.mycompose.ui.screen.selection
+
+data class AgreementOption(
+    val id: Int,
+    val name: String,
+)
+
+fun getAgreementOptions(): List<AgreementOption> {
+    return listOf(
+        AgreementOption(1, "첫 번째 약관 동의"),
+        AgreementOption(2, "두 번째 약관 동의"),
+        AgreementOption(3, "세 번째 약관 동의")
+    )
+}

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/AgreementState.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/AgreementState.kt
@@ -1,0 +1,7 @@
+package com.chch.mycompose.ui.screen.selection
+
+enum class AgreementState(val displayName: String) {
+    ALL("All"),
+    NONE("None"),
+    INDETERMINATE("Indeterminate");
+}

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/Gender.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/Gender.kt
@@ -1,0 +1,9 @@
+package com.chch.mycompose.ui.screen.selection
+
+enum class Gender(val displayName: String) {
+    FEMALE("Female"), MALE("Male"), NON_BINARY("Non-binary");
+
+    companion object {
+        fun values() = entries.toTypedArray()
+    }
+}

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
@@ -1,0 +1,55 @@
+package com.chch.mycompose.ui.screen.selection
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.chch.mycompose.ui.component.BorderedSection
+import com.chch.mycompose.ui.component.RadioWithText
+
+@Composable
+fun RadioCheckboxPage(
+    nc: NavController,
+) {
+    var selectedGender by remember { mutableStateOf(Gender.FEMALE) }
+
+    Column(Modifier.fillMaxSize()) {
+
+        // Radio buttons for Gender
+        BorderedSection(
+            title = "Gender"
+        ) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp)
+                    .selectableGroup()
+            ) {
+
+                Gender.entries.forEach { gender ->
+                    RadioWithText(
+                        modifier = Modifier.weight(1f),
+                        selected = gender == selectedGender,
+                        text = gender.displayName,
+                    ) {
+                        selectedGender = gender
+                    }
+                }
+            }
+        }
+
+        //
+    }
+
+
+}

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,12 +29,29 @@ import com.chch.mycompose.ui.component.RadioWithText
 fun RadioCheckboxPage(
     nc: NavController,
 ) {
+    val scrollState = rememberScrollState()
+
     var selectedGender by remember { mutableStateOf(Gender.FEMALE) }
 
     val toppingList = getToppingList()
     var selectedToppings by remember { mutableStateOf(setOf<Topping>()) }
 
-    Column(Modifier.fillMaxSize()) {
+    val agreementOptions = getAgreementOptions()
+    var selectedAgreementOptions by remember { mutableStateOf(setOf<AgreementOption>()) }
+
+    val radioState by remember(selectedAgreementOptions) {
+        derivedStateOf {
+            when (selectedAgreementOptions.size) {
+                0 -> AgreementState.NONE
+                agreementOptions.size -> AgreementState.ALL
+                else -> AgreementState.INDETERMINATE
+            }
+        }
+    }
+
+    Column(Modifier
+        .fillMaxSize()
+        .verticalScroll(scrollState)) {
 
         // Radio buttons for Gender
         BorderedSection(
@@ -84,6 +104,59 @@ fun RadioCheckboxPage(
             }
         }
 
+        Spacer(Modifier.height(20.dp))
+
+        // Radio Button with Checkbox
+        BorderedSection(
+            title = "Agreement"
+        ) {
+
+            Column {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp)
+                        .selectableGroup()
+                ) {
+
+                    AgreementState.entries.forEach { state ->
+                        RadioWithText(
+                            modifier = Modifier.weight(1f),
+                            selected = state == radioState,
+                            text = state.displayName,
+                        ) {
+                            when (state) {
+                                AgreementState.ALL -> selectedAgreementOptions =
+                                    agreementOptions.toSet()
+
+                                AgreementState.NONE -> selectedAgreementOptions = emptySet()
+                                AgreementState.INDETERMINATE -> {
+                                    // Do Nothing
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Column {
+                    agreementOptions.forEach { opt ->
+                        CheckboxWithText(
+                            text = opt.name,
+                            checked = selectedAgreementOptions.contains(opt)
+                        ) { checked ->
+                            selectedAgreementOptions = if (checked) {
+                                selectedAgreementOptions + opt
+                            } else {
+                                selectedAgreementOptions - opt
+                            }
+                        }
+                    }
+                }
+
+            }
+
+
+        }
     }
 
 

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/RadioCheckboxPage.kt
@@ -2,19 +2,24 @@ package com.chch.mycompose.ui.screen.selection
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.chch.mycompose.ui.component.BorderedSection
+import com.chch.mycompose.ui.component.CheckboxWithText
 import com.chch.mycompose.ui.component.RadioWithText
 
 @Composable
@@ -22,6 +27,9 @@ fun RadioCheckboxPage(
     nc: NavController,
 ) {
     var selectedGender by remember { mutableStateOf(Gender.FEMALE) }
+
+    val toppingList = getToppingList()
+    var selectedToppings by remember { mutableStateOf(setOf<Topping>()) }
 
     Column(Modifier.fillMaxSize()) {
 
@@ -48,7 +56,34 @@ fun RadioCheckboxPage(
             }
         }
 
-        //
+        Spacer(Modifier.height(20.dp))
+
+        // Checkbox Sample Example
+        BorderedSection(
+            title = "Extra Toppings"
+        ) {
+            Column {
+                toppingList.forEach { topping ->
+                    CheckboxWithText(
+                        text = "${topping.name} (+${topping.price})",
+                        checked = selectedToppings.contains(topping)
+                    ) { checked ->
+                        selectedToppings = if (checked) {
+                            selectedToppings + topping
+                        } else {
+                            selectedToppings - topping
+                        }
+                    }
+                }
+
+                Text(
+                    text = "Additional amount: ${selectedToppings.sumOf { it.price }}",
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(top = 10.dp, start = 12.dp)
+                )
+            }
+        }
+
     }
 
 

--- a/app/src/main/java/com/chch/mycompose/ui/screen/selection/Topping.kt
+++ b/app/src/main/java/com/chch/mycompose/ui/screen/selection/Topping.kt
@@ -1,0 +1,19 @@
+package com.chch.mycompose.ui.screen.selection
+
+data class Topping(
+    val id: Int,
+    val name: String,
+    val price: Int,
+)
+
+fun getToppingList(): List<Topping> {
+
+    return listOf(
+        Topping(1, "glass noodles", 2000),
+        Topping(2, "Mushroom set", 3000),
+        Topping(3, "10 quail eggs", 3000),
+        Topping(4, "10 rice cakes", 1000),
+        Topping(5, "10 Vienna sausages", 2000),
+        Topping(6, "Bok choy", 2000),
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="modalbottomsheet">ModalBottomSheet</string>
     <string name="bottomsheetscaffold">BottomSheetScaffold</string>
     <string name="checklist">Checklist</string>
+    <string name="radio_and_checkbox">Radio Button and Checkbox</string>
 
     <string name="confirm">Confirm</string>
     <string name="dismiss">Dismiss</string>


### PR DESCRIPTION
### Overview
1. **Radio Button Sample**  
   - Basic usage of radio buttons with selection state

2. **Checkbox Sample**  
   - Multiple checkboxes with individual selection state management

3. **Combined Radio-Checkbox Sample**  
   - Sync logic between radio buttons and checkboxes:
   - Radio reflects current checkbox selection state (`All`, `Indeterminate`, `None`)
   - Selecting a radio button updates the checkbox selection accordingly
   - Uses `derivedStateOf` for automatic state derivation

### Motivation
To illustrate different patterns of selection controls and how they can be combined or used separately in a Compose UI.

### Notes
- `Set<String>` is used to manage checkbox selections
- `SelectState` enum represents high-level selection state
- `remember` and `derivedStateOf` are used for reactive updates